### PR TITLE
Deprecate plugin references

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -10,7 +10,7 @@ from starlite import Starlite
 from starlite.middleware.session.memory_backend import MemoryBackendConfig
 from starlite.plugins.sql_alchemy import SQLAlchemyConfig, SQLAlchemyPlugin
 
-from starlite_users import StarliteUsersConfig, StarliteUsersPlugin
+from starlite_users import StarliteUsers, StarliteUsersConfig
 from starlite_users.adapter.sqlalchemy.guid import GUID
 from starlite_users.adapter.sqlalchemy.models import (
     SQLAlchemyRoleModel,
@@ -133,7 +133,7 @@ async def on_startup() -> None:
             session.add_all([admin_role, admin_user])
 
 
-starlite_users = StarliteUsersPlugin(
+starlite_users = StarliteUsers(
     config=StarliteUsersConfig(
         auth_backend="session",
         secret=ENCODING_SECRET,

--- a/starlite_users/__init__.py
+++ b/starlite_users/__init__.py
@@ -1,4 +1,4 @@
 from .config import StarliteUsersConfig
-from .plugin import StarliteUsersPlugin
+from .main import StarliteUsers
 
-__all__ = ["StarliteUsersPlugin", "StarliteUsersConfig"]
+__all__ = ["StarliteUsers", "StarliteUsersConfig"]

--- a/starlite_users/config.py
+++ b/starlite_users/config.py
@@ -127,7 +127,7 @@ class VerificationHandlerConfig(BaseModel):
 
 
 class StarliteUsersConfig(BaseModel, Generic[UserModelType]):
-    """Configuration class for StarliteUsersPlugin."""
+    """Configuration class for StarliteUsers."""
 
     class Config:
         arbitrary_types_allowed = True

--- a/starlite_users/main.py
+++ b/starlite_users/main.py
@@ -38,8 +38,8 @@ EXCLUDE_AUTH_HANDLERS = (
 )
 
 
-class StarliteUsersPlugin:
-    """A Plugin for authentication, authorization and user management."""
+class StarliteUsers:
+    """A Starlite extension for authentication, authorization and user management."""
 
     def __init__(self, config: StarliteUsersConfig) -> None:
         self._config = config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from starlite.middleware.session.memory_backend import MemoryBackendConfig
 from starlite.plugins.sql_alchemy import SQLAlchemyConfig, SQLAlchemyPlugin
 from starlite.testing import TestClient
 
-from starlite_users import StarliteUsersConfig, StarliteUsersPlugin
+from starlite_users import StarliteUsers, StarliteUsersConfig
 from starlite_users.adapter.sqlalchemy.models import (
     SQLAlchemyRoleModel,
     SQLAlchemyUserModel,
@@ -254,7 +254,7 @@ class MockSQLAlchemyUserRepository(Generic[UserModelType]):
         pytest.param("jwt_cookie", id="jwt_cookie"),
     ],
 )
-def plugin_config(request: pytest.FixtureRequest) -> StarliteUsersConfig:
+def starlite_users_config(request: pytest.FixtureRequest) -> StarliteUsersConfig:
     return StarliteUsersConfig(
         auth_backend=request.param,
         secret=ENCODING_SECRET,
@@ -278,16 +278,16 @@ def plugin_config(request: pytest.FixtureRequest) -> StarliteUsersConfig:
     )
 
 
-@pytest.fixture(scope="module")
-def plugin(plugin_config: StarliteUsersConfig) -> StarliteUsersPlugin:
-    return StarliteUsersPlugin(config=plugin_config)
+@pytest.fixture()
+def starlite_users(starlite_users_config: StarliteUsersConfig) -> StarliteUsers:
+    return StarliteUsers(config=starlite_users_config)
 
 
-@pytest.fixture(scope="module")
-def app(plugin: StarliteUsersPlugin) -> Starlite:
+@pytest.fixture()
+def app(starlite_users: StarliteUsers) -> Starlite:
     return Starlite(
         debug=True,
-        on_app_init=[plugin.on_app_init],
+        on_app_init=[starlite_users.on_app_init],
         plugins=[
             SQLAlchemyPlugin(
                 config=SQLAlchemyConfig(
@@ -341,8 +341,8 @@ def mock_user_repository(
 
 
 @pytest.fixture()
-def mock_auth(client: TestClient, plugin_config: StarliteUsersConfig) -> MockAuth:
-    return MockAuth(client=client, config=plugin_config)
+def mock_auth(client: TestClient, starlite_users_config: StarliteUsersConfig) -> MockAuth:
+    return MockAuth(client=client, config=starlite_users_config)
 
 
 @pytest.fixture()

--- a/tests/test_route_handlers.py
+++ b/tests/test_route_handlers.py
@@ -20,10 +20,10 @@ def test_login(client: TestClient) -> None:
 
 
 @pytest.mark.usefixtures("mock_user_repository")
-def test_logout(client: TestClient, generic_user: User, plugin_config: StarliteUsersConfig) -> None:
+def test_logout(client: TestClient, generic_user: User, starlite_users_config: StarliteUsersConfig) -> None:
     client.set_session_data({"user_id": str(generic_user.id)})
     response = client.post("/logout")
-    if plugin_config.auth_backend != "session":
+    if starlite_users_config.auth_backend != "session":
         assert response.status_code == 404
     else:
         assert response.status_code == 201

--- a/tests/test_starlite_users.py
+++ b/tests/test_starlite_users.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from starlite_users.plugin import EXCLUDE_AUTH_HANDLERS
+from starlite_users.main import EXCLUDE_AUTH_HANDLERS
 
 if TYPE_CHECKING:
     from starlite import Starlite


### PR DESCRIPTION
Remove references relating to "plugin", since we're not implementing Starlite's `PluginProtocol`, which might lead to confusion.