### PR TITLE
Split login routes

### DIFF
--- a/starlite_users/main.py
+++ b/starlite_users/main.py
@@ -31,7 +31,8 @@ if TYPE_CHECKING:
     from starlite_users.config import StarliteUsersConfig
 
 EXCLUDE_AUTH_HANDLERS = (
-    "login",
+    "login_jwt",
+    "login_session",
     "register",
     "verify",
     "forgot_password",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,3 +1,4 @@
 from pydantic import SecretStr
 
 ENCODING_SECRET = SecretStr("1234567890abcdef")
+DEFAULT_AUTH_EXCLUDE_PATHS = ("/login", "/register", "/verify", "/forgot-password", "/reset-password")

--- a/tests/test_starlite_users.py
+++ b/tests/test_starlite_users.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from starlite_users.main import EXCLUDE_AUTH_HANDLERS
+from tests.constants import DEFAULT_AUTH_EXCLUDE_PATHS
 
 if TYPE_CHECKING:
     from starlite import Starlite
@@ -12,6 +12,4 @@ def test_auth_exclude_paths(app: "Starlite") -> None:
     elif hasattr(app.middleware[0], "kwargs") and app.middleware[0].kwargs.get("exclude"):  # pyright: ignore
         excluded_paths = app.middleware[0].kwargs["exclude"]  # pyright: ignore
 
-    assert all(
-        f'/{handler.replace("_", "-")}' in excluded_paths for handler in EXCLUDE_AUTH_HANDLERS  # pyright: ignore
-    )
+    assert all(path in excluded_paths for path in DEFAULT_AUTH_EXCLUDE_PATHS)  # pyright: ignore


### PR DESCRIPTION
Split jwt and session login routes to reduce complexity and ease typing.

This also aims to fix a bug where instantiating a custom Starlite `Response` on the login route would bypass any set type encoders, resulting in errors if the DTO contains non-standard types like `asyncpg.pgproto.UUID`